### PR TITLE
Change WAD's driver to open as a subprocess without a window shown on GUIs

### DIFF
--- a/WADLibrary/Driver.py
+++ b/WADLibrary/Driver.py
@@ -11,7 +11,7 @@ class Driver:
         self.driver_path = driver_path
 
     def set_up_driver(self, path=None):
-        """Starts the Windows Application Driver as a detached process.
+        """Starts the Windows Application Driver as a subprocess.
 
         Arguments detailed:
         | =Argument= | =Input=                                |

--- a/WADLibrary/Driver.py
+++ b/WADLibrary/Driver.py
@@ -22,8 +22,10 @@ class Driver:
         """
         if path is None:
             path = self.driver_path
-        self.process = subprocess.Popen([path], shell=True, stdin=None, stdout=self.f, stderr=None, close_fds=False,
-                                        creationflags=8)  # subprocess.DETACHED_PROCESS
+        si = subprocess.STARTUPINFO()
+        si.dwFlags = subprocess.STARTF_USESHOWWINDOW
+        si.wShowWindow = 0
+        self.process = subprocess.Popen([path], startupinfo=si, creationflags=subprocess.CREATE_NEW_CONSOLE)
 
     def tear_down_driver(self):
         """Stops the Windows Application Driver."""


### PR DESCRIPTION
As compared to the upstream project, the driver was changed to open as a `DETACHED_PROCESS` in order to work with e.g. CI systems and other use cases where the setup is initialized by a parent process. This introduced the downside of having the WAD's console window always visible on the OS's GUI. This PR reverts that behavior (i.e. WinAppDriver.exe will run as a background process) while still meeting the requirement of working with e.g. CI systems as expected.